### PR TITLE
Add Prometheus textfile telemetry for sync counts (dual-send with zabbix_sender)

### DIFF
--- a/deploy/roles/deploy/tasks/service.yml
+++ b/deploy/roles/deploy/tasks/service.yml
@@ -1,3 +1,12 @@
+# group is created by the vm-agent role (leihs-inventory) — deploy that
+# role first on hosts that enable prom_textfile_dir
+- name: add app user to prom-textfile group (textfile-collector write access)
+  user:
+    name: '{{app_user}}'
+    groups: prom-textfile
+    append: yes
+  when: prom_textfile_dir | default('') | length > 0
+
 - name: copy {{app_name}}.service
   template:
     src: 'sync.service'

--- a/deploy/roles/deploy/templates/sync.service
+++ b/deploy/roles/deploy/templates/sync.service
@@ -12,6 +12,10 @@ RemainAfterExit=false
 WorkingDirectory={{app_dir}}
 User={{app_user}}
 Group={{app_user}}
+{% if prom_textfile_dir | default('') %}
+Environment=PROM_TEXTFILE_PATH={{prom_textfile_dir}}/{{app_name}}-counts.prom
+Environment=PROM_JOB_LABEL={{app_name}}
+{% endif %}
 ExecStart=/usr/bin/java "-Xmx1g" "-jar" "{{app_dir}}/leihs-sync.jar" \
   "-c" "{{config_file_target}}" "run"
 

--- a/deps.edn
+++ b/deps.edn
@@ -43,4 +43,9 @@
 
   :resource-paths ["resources"]
 
+  :test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts ["-m" "cognitect.test-runner"]}
+
   }}

--- a/src/funswiss/leihs_sync/main.clj
+++ b/src/funswiss/leihs_sync/main.clj
@@ -8,6 +8,7 @@
    [clojure.tools.cli :as cli]
    [funswiss.leihs-sync.leihs.core :as leihs-core]
    [funswiss.leihs-sync.ms.core :as ms-core]
+   [funswiss.leihs-sync.prom-textfile :as prom-textfile]
    [funswiss.leihs-sync.sync.core :as sync-core]
    [funswiss.leihs-sync.utils.cli-options :as cli-opts]
    [funswiss.leihs-sync.utils.core :refer [deep-merge-limited keyword presence str get! get-in!]]
@@ -129,7 +130,8 @@
                   (sync-core/start @config*)
                   (when-let [prtg-url (get @config* :prtg-url)]
                     (prtg/send-success prtg-url @sync-core/state*))
-                  (zabbix-sender/send-success @config* @sync-core/state*)))
+                  (zabbix-sender/send-success @config* @sync-core/state*)
+                  (prom-textfile/send-success @sync-core/state*)))
       (catch Throwable th
         (reset! exception* th)
         (logging/error (thrown/stringify th))

--- a/src/funswiss/leihs_sync/prom_textfile.clj
+++ b/src/funswiss/leihs_sync/prom_textfile.clj
@@ -2,7 +2,11 @@
   (:refer-clojure :exclude [str])
   (:require
    [clojure.string :as string]
-   [funswiss.leihs-sync.utils.core :refer [str]]))
+   [funswiss.leihs-sync.utils.core :refer [presence str]]
+   [taoensso.timbre :as logging])
+  (:import
+   [java.io File]
+   [java.nio.file CopyOption Files StandardCopyOption]))
 
 (def count-keys
   ;; keep in sync with zabbix-sender/send-success select-keys
@@ -21,7 +25,10 @@
   (str "leihs_sync_" (string/replace (name k) "-" "_")))
 
 (defn- escape-label [s]
-  (-> s (string/replace "\\" "\\\\") (string/replace "\"" "\\\"")))
+  (-> s
+      (string/replace "\\" "\\\\")
+      (string/replace "\"" "\\\"")
+      (string/replace "\n" "\\n")))
 
 (defn render
   "Prometheus text exposition of the sync-count gauges plus a
@@ -35,3 +42,36 @@
               (map #(line (metric-name %) (get state %)))
               (apply str))
          (line "leihs_sync_last_success_timestamp_seconds" epoch-seconds))))
+
+(defn write!
+  "Atomically writes the rendered exposition to path-str:
+  tmp file in the same directory, world-readable, then ATOMIC_MOVE.
+  node_exporter (different user, not in our group) must be able to read it."
+  [path-str job-label state]
+  (let [target (File. path-str)
+        tmp (File/createTempFile (.getName target) ".tmp"
+                                 (.getParentFile target))]
+    (try
+      (spit tmp (render job-label state (quot (System/currentTimeMillis) 1000)))
+      (.setReadable tmp true false)
+      (Files/move
+       (.toPath tmp) (.toPath target)
+       (into-array CopyOption
+                   [StandardCopyOption/ATOMIC_MOVE
+                    StandardCopyOption/REPLACE_EXISTING]))
+      (finally (.delete tmp)))))
+
+(defn send-success
+  "Dual-send lane next to zabbix-sender: writes count gauges to the
+  node_exporter textfile collector. Toggled by PROM_TEXTFILE_PATH
+  (full target path, set by the systemd unit); unset = disabled.
+  Throws on write failure — same contract as zabbix-sender (run is
+  marked failed, Failed Systemd Units alert picks it up)."
+  [state]
+  (if-let [path (presence (System/getenv "PROM_TEXTFILE_PATH"))]
+    (let [job (or (presence (System/getenv "PROM_JOB_LABEL"))
+                  (-> path File. .getName
+                      (string/replace #"-counts\.prom$" "")))]
+      (logging/info "prom-textfile: writing " path)
+      (write! path job state))
+    (logging/info "prom-textfile: skipped, PROM_TEXTFILE_PATH not set")))

--- a/src/funswiss/leihs_sync/prom_textfile.clj
+++ b/src/funswiss/leihs_sync/prom_textfile.clj
@@ -72,6 +72,6 @@
     (let [job (or (presence (System/getenv "PROM_JOB_LABEL"))
                   (-> path File. .getName
                       (string/replace #"-counts\.prom$" "")))]
-      (logging/info "prom-textfile: writing " path)
+      (logging/info "prom-textfile: writing" path)
       (write! path job state))
     (logging/info "prom-textfile: skipped, PROM_TEXTFILE_PATH not set")))

--- a/src/funswiss/leihs_sync/prom_textfile.clj
+++ b/src/funswiss/leihs_sync/prom_textfile.clj
@@ -1,0 +1,37 @@
+(ns funswiss.leihs-sync.prom-textfile
+  (:refer-clojure :exclude [str])
+  (:require
+   [clojure.string :as string]
+   [funswiss.leihs-sync.utils.core :refer [str]]))
+
+(def count-keys
+  ;; keep in sync with zabbix-sender/send-success select-keys
+  [:groups-created-count
+   :groups-deleted-count
+   :groups-updated-count
+   :groups-users-updated-count
+   :users-created-count
+   :users-deleted-count
+   :users-disabled-count
+   :users-updated-count
+   :users-total-disabled-count
+   :users-total-enabled-count])
+
+(defn- metric-name [k]
+  (str "leihs_sync_" (string/replace (name k) "-" "_")))
+
+(defn- escape-label [s]
+  (-> s (string/replace "\\" "\\\\") (string/replace "\"" "\\\"")))
+
+(defn render
+  "Prometheus text exposition of the sync-count gauges plus a
+  last-success timestamp. Emits only keys present in state."
+  [job-label state epoch-seconds]
+  (let [job (escape-label job-label)
+        line (fn [n v] (str "# TYPE " n " gauge\n"
+                            n "{job=\"" job "\"} " v "\n"))]
+    (str (->> count-keys
+              (filter #(contains? state %))
+              (map #(line (metric-name %) (get state %)))
+              (apply str))
+         (line "leihs_sync_last_success_timestamp_seconds" epoch-seconds))))

--- a/test/funswiss/leihs_sync/prom_textfile_test.clj
+++ b/test/funswiss/leihs_sync/prom_textfile_test.clj
@@ -19,3 +19,21 @@
   (let [out (prom/render "x" {:users-created-count 0} 1)]
     (is (not (re-find #"users_deleted" out)))
     (is (re-find #"(?m)^leihs_sync_users_created_count\{job=\"x\"\} 0$" out))))
+
+(deftest render-escapes-label-values
+  (let [out (prom/render "a\\b\"c\nd" {:users-created-count 1} 1)]
+    (is (re-find #"(?m)^leihs_sync_users_created_count\{job=\"a\\\\b\\\"c\\nd\"\} 1$" out))))
+
+(deftest write!-creates-world-readable-file-and-no-tmp-leftovers
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "prom-test" (make-array java.nio.file.attribute.FileAttribute 0)))
+        target (java.io.File. dir "leihs-functional-sync-counts.prom")]
+    (prom/write! (.getPath target) "leihs-functional-sync" state)
+    (is (.exists target))
+    (is (re-find #"leihs_sync_users_created_count" (slurp target)))
+    (is (.canRead target)) ; readable
+    (is (= 1 (count (.listFiles dir)))))) ; tmp file cleaned up
+
+(deftest send-success-skips-when-env-unset
+  ;; PROM_TEXTFILE_PATH is not set in the test environment
+  (is (nil? (prom/send-success state))))

--- a/test/funswiss/leihs_sync/prom_textfile_test.clj
+++ b/test/funswiss/leihs_sync/prom_textfile_test.clj
@@ -1,0 +1,21 @@
+(ns funswiss.leihs-sync.prom-textfile-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [funswiss.leihs-sync.prom-textfile :as prom]))
+
+(def state
+  {:users-created-count 3
+   :users-total-enabled-count 42
+   :irrelevant-key "ignored"})
+
+(deftest render-emits-present-count-keys-with-job-label
+  (let [out (prom/render "leihs-functional-sync" state 1752300000)]
+    (is (re-find #"(?m)^leihs_sync_users_created_count\{job=\"leihs-functional-sync\"\} 3$" out))
+    (is (re-find #"(?m)^leihs_sync_users_total_enabled_count\{job=\"leihs-functional-sync\"\} 42$" out))
+    (is (re-find #"(?m)^leihs_sync_last_success_timestamp_seconds\{job=\"leihs-functional-sync\"\} 1752300000$" out))
+    (is (re-find #"(?m)^# TYPE leihs_sync_users_created_count gauge$" out))))
+
+(deftest render-omits-absent-keys
+  (let [out (prom/render "x" {:users-created-count 0} 1)]
+    (is (not (re-find #"users_deleted" out)))
+    (is (re-find #"(?m)^leihs_sync_users_created_count\{job=\"x\"\} 0$" out))))


### PR DESCRIPTION
## Motivation

The sync jobs currently push their per-run counts (users/groups created, deleted, updated, total enabled/disabled) only via `zabbix_sender`. The new VictoriaMetrics/Grafana monitoring stack has no equivalent — a sync that runs "successfully" but is logically broken (e.g. the client-secret expiry earlier this year: enabled-users would have dropped to a visibly wrong value) is invisible there. This PR adds a second delivery lane so both systems receive the counts during the migration soak; the Zabbix path is untouched.

## What this does

- **New namespace `funswiss.leihs-sync.prom-textfile`** — renders the same 10 count keys `zabbix-sender/send-success` selects (plus a `leihs_sync_last_success_timestamp_seconds` gauge) in Prometheus text-exposition format, and atomically writes them (tmp file + `ATOMIC_MOVE`, world-readable) into the node_exporter textfile-collector directory.
- **`main.clj`** — calls `prom-textfile/send-success` on the success path, directly after the zabbix-sender call. Same failure contract as zabbix-sender: a write failure throws, the run exits non-zero, and systemd-unit monitoring picks it up. (Consequence of the ordering: if zabbix-sender throws, the prom file is not written for that run.)
- **Deploy role** — the systemd unit template gains two `Environment=` lines (`PROM_TEXTFILE_PATH`, `PROM_JOB_LABEL`), emitted only when the new Ansible var `prom_textfile_dir` is defined; `service.yml` adds the app user to the `prom-textfile` group (same idiom as the existing zabbix group task). The group and the writable collector directory are provided by the `vm-agent` role in leihs-inventory, so that role must be deployed first on any host that opts in.
- **Test runner** — adds a `:test` alias (cognitect test-runner) and a test namespace; this is the repo's first unit-test setup, kept minimal.

## Activation & rollback

Entirely env-driven: without `PROM_TEXTFILE_PATH` the code logs "skipped" and does nothing, and without `prom_textfile_dir` the rendered unit file is byte-identical to before — so this is safe to merge ahead of any host rollout. Rollback per host = remove the var and redeploy. Rollout plan: uni-muster only for integration testing; no customer hosts until this is merged.

## Metric shape

```
# TYPE leihs_sync_users_created_count gauge
leihs_sync_users_created_count{job="leihs-functional-sync"} 3
...
leihs_sync_last_success_timestamp_seconds{job="leihs-functional-sync"} 1752300000
```

(The `job` label is relabeled to `exported_job` by the scrape pipeline, matching the existing batch-job metrics.)

## How to test

```
clojure -M:test        # 5 tests, 12 assertions
clojure -T:build uber  # or bin/clj-uberjar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQ77qfTKrrHb3qdjaaR72T
